### PR TITLE
Added missing comma in list of win32 executable templates.

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -51,7 +51,7 @@ class ClarisseLauncher(SoftwareLauncher):
         ],
         "win32": [
             "C:/Program Files/Isotropix/Clarisse iFX {version}{minor}/Clarisse/clarisse.exe",
-            "C:/Program Files/Isotropix/Clarisse iFX {version}{minor} {service_pack}/Clarisse/clarisse.exe"
+            "C:/Program Files/Isotropix/Clarisse iFX {version}{minor} {service_pack}/Clarisse/clarisse.exe",
             "$CLARISSE_BIN_DIR/clarisse.exe"
         ],
         "linux2": [


### PR DESCRIPTION
Adding the missing comma, to fix executable discovery in win32 when using a service-pack version. Thanks!